### PR TITLE
Corrected user creationDate to use current time with moment.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,10 +44,7 @@ async function run() {
       const newUser = {
         email: user.email,
         name: user.name,
-        creationDate: moment
-          .utc("2025-03-20T07:51:31.978Z")
-          .tz("Asia/Dhaka")
-          .format("YYYY-MM-DD hh:mm:ss A"),
+        creationDate: moment().tz("Asia/Dhaka").format("YYYY-MM-DD hh:mm:ss A"),
         role: "user",
         isActive: true,
         lastLogin: null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,9 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
-
         "moment-timezone": "^0.5.47",
-        "mongodb": "^6.14.2"
+        "mongodb": "^6.14.2",
         "swiftrent-server": "file:"
-
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -533,6 +531,7 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -541,6 +540,7 @@
       "version": "0.5.47",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.47.tgz",
       "integrity": "sha512-UbNt/JAWS0m/NJOebR0QMRHBk0hu03r5dx9GK8Cs0AS3I81yDcOc9k+DytPItgVvBP7J6Mf6U2n3BPAacAV9oA==",
+      "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4"
       },


### PR DESCRIPTION
### Description
- Fixed an issue with the `creationDate` field where a static UTC timestamp was used.
- Implemented `moment().tz("Asia/Dhaka")` to store the current local time during user registration.
- Ensured proper timezone management using moment-timezone.

### Changes
- Modified `POST /add-user` API to generate the user creation time using the correct timezone.

### Testing
- Tested user registration with different accounts.
- Verified the creationDate now stores the current time in Asia/Dhaka timezone.
- Confirmed the database reflects accurate timestamps.
