### PR TITLE
Add finish-trip API to complete trips across collections

### DIFF
--- a/index.js
+++ b/index.js
@@ -385,6 +385,37 @@ async function run() {
       }
     });
 
+    // Finish Trip
+    app.post("/finish-trip/:id", async (req, res) => {
+      const id = req.params.id;
+      const { driverEmail } = req.body;
+
+      try {
+        // driverAssignments Collection tripStatus UpDate
+        const assignmentUpdate = await driverAssignmentsCollection.updateOne(
+          { bookingId: id, driverEmail: driverEmail, tripStatus: "Started" },
+          { $set: { tripStatus: "Completed" } }
+        );
+
+        if (assignmentUpdate.matchedCount === 0) {
+          return res.status(400).send({ message: "Trip cannot be finished" });
+        }
+
+        // bookings Collection tripStatus Update
+        await bookingsCollection.updateOne(
+          { _id: new ObjectId(id) },
+          { $set: { tripStatus: "Completed" } }
+        );
+
+        res.send({ message: "Trip finished successfully" });
+      } catch (error) {
+        console.error("Error finishing trip:", error);
+        res
+          .status(500)
+          .send({ message: "Failed to finish trip", error: error.message });
+      }
+    });
+
     // Get driver assignments by email
     app.get("/driver-assignments/:email", async (req, res) => {
       try {


### PR DESCRIPTION
### What this PR does

- Implements a `POST /finish-trip/:id` endpoint
- Updates `tripStatus` from "Started" to "Completed" in both:
  - `driverAssignmentsCollection`
  - `bookingsCollection`
- Ensures the trip can only be marked completed if it's currently "Started"

### Why

To allow drivers to finish their assigned trips properly and maintain data consistency across collections.

### Notes

- Returns `400` if the trip is not in "Started" state or not matched
- Returns a success message on successful completion
