### PR TITLE
Add API to fetch completed trip history for specific driver by email

### DIFF
--- a/index.js
+++ b/index.js
@@ -432,6 +432,19 @@ async function run() {
       }
     });
 
+    // Get trip history for a specific driver
+    app.get('/trip-history/:email', async (req, res) => {
+      try {
+        const email = req.params.email;
+        const query = { driverEmail: email, tripStatus: 'Completed' };
+        const trips = await driverAssignmentsCollection.find(query).toArray();
+        res.status(200).send(trips);
+      } catch (error) {
+        console.error('Error fetching trip history:', error);
+        res.status(500).send({ message: 'Failed to fetch trip history', error });
+      }
+    });
+
     // Pick Trip
     app.post("/pick-trip/:id", async (req, res) => {
       const id = req.params.id;


### PR DESCRIPTION
### What’s Added:
- Created a new `GET /trip-history/:email` endpoint.
- Filters trips by driver email and returns only trips with status `'Completed'`.
- Connected to `driverAssignmentsCollection` to fetch relevant data.

### Why:
- Enables frontend to fetch personalized trip history for the logged-in driver.
- Supports dynamic rendering of trip history on the frontend side.

### How to Test:
- Hit the endpoint `/trip-history/{driverEmail}` using Postman or browser.
- Ensure it returns a list of completed trips related to that email.
- If no data is found, it should return an empty array.

### Error Handling:
- Server responds with status 500 and an error message if fetching fails.
