### PR TITLE
Add API to block user by email

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ const uri = `mongodb+srv://${process.env.DB_USER}:${process.env.DB_PASS}@cluster
 
 // const uri = 'mongodb://localhost:27017/';
 
-
 // Create a MongoClient with a MongoClientOptions object to set the Stable API version
 const client = new MongoClient(uri, {
   serverApi: {
@@ -610,6 +609,27 @@ async function run() {
     });
 
     // -----------
+
+    // user block api
+    app.patch("/block-user/:email", async (req, res) => {
+      const email = req.params.email;
+      try {
+        const result = await userInfoCollection.updateOne(
+          { "userInfo.email": email },
+          { $set: { isBlock: true } }
+        );
+        if (result.modifiedCount > 0) {
+          res.send({ message: "User blocked successfully" });
+        } else {
+          res.status(404).send({ message: "User not found" });
+        }
+      } catch (error) {
+        res.status(500).send({ message: "Server error", error: error.message });
+      }
+    });
+
+    
+
     app.patch("/update-last-login", async (req, res) => {
       try {
         const { email } = req.body;
@@ -632,7 +652,6 @@ async function run() {
         res.send({ message: "Last login updated successfully" });
       } catch (error) {
         res.status(500).send({ message: "Internal Server Error" });
-
       }
     });
     // update active status


### PR DESCRIPTION
- Created a new PATCH API endpoint: /block-user/:email
- This API sets isBlock: true for the given user's email.
- Sends success message if user is found and blocked.
- Sends 404 if user not found.
- Sends 500 error on server failure.
